### PR TITLE
Added support for in memory BytesIO GeoJSON for boundary param

### DIFF
--- a/outreachy.py
+++ b/outreachy.py
@@ -1,0 +1,14 @@
+from osm_fieldwork.basemapper import create_basemap_file
+from io import BytesIO
+
+with open(r"D:\Opensource\osm-fieldwork\tests\testdata\Rollinsville.geojson", "rb") as geojson_file:
+    boundary = geojson_file.read()
+    boundary_bytesio = BytesIO(boundary)  # add to the BytesIO wrapper
+
+create_basemap_file(
+    verbose=True,
+    boundary=boundary_bytesio,
+    outfile="outreachy.mbtiles",
+    zooms="12-15",
+    source="esri",
+)

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -22,6 +22,7 @@
 import logging
 import os
 import shutil
+from io import BytesIO
 
 from osm_fieldwork.basemapper import BaseMapper
 from osm_fieldwork.sqlite import DataFile
@@ -32,20 +33,13 @@ rootdir = os.path.dirname(os.path.abspath(__file__))
 boundary = f"{rootdir}/testdata/Rollinsville.geojson"
 outfile = f"{rootdir}/testdata/rollinsville.mbtiles"
 base = "./tiles"
-# boundary = open(infile, "r")
-# poly = geojson.load(boundary)
-# if "features" in poly:
-#    geometry = shape(poly["features"][0]["geometry"])
-# elif "geometry" in poly:
-#    geometry = shape(poly["geometry"])
-# else:
-#    geometry = shape(poly)
 
 
-def test_create():
-    """See if the file got loaded."""
+def test_create_with_bytesio():
     hits = 0
-    basemap = BaseMapper(boundary, base, "topo", False)
+    with open(boundary, "rb") as geojson_file:
+        boundary_bytesio = BytesIO(geojson_file.read())
+    basemap = BaseMapper(boundary_bytesio, base, "topo", False)
     tiles = list()
     for level in [8, 9, 10, 11, 12]:
         basemap.getTiles(level)
@@ -67,4 +61,4 @@ def test_create():
 
 
 if __name__ == "__main__":
-    test_create()
+    test_create_with_bytesio()


### PR DESCRIPTION
**Description**

This pull request resolves this [issue](https://github.com/hotosm/osm-fieldwork/issues/204) by improving the functionality of the basemapper.py module to support BytesIO GeoJSON for the boundary parameter, facilitating in-memory handling of GeoJSON data. To achieve this, the following changes have been implemented:

1. Made changes to basemapper.py file to accept BytesIO GeoJSON data for the boundary parameter.
2. Added outreachy.py file
3. Added test_create_with_bytesio() unit test for verification.
4. Modified comments according to the updated code.